### PR TITLE
Update default.meta

### DIFF
--- a/metadata/default.meta
+++ b/metadata/default.meta
@@ -3,3 +3,6 @@
 # Export configurations globally (system wide)
 []
 export = system
+
+[]
+access = read : [ * ], write : [ admin, power ]


### PR DESCRIPTION
Added  access and write permissions to default.meta. This is required for the application to work in Splunk Cloud.